### PR TITLE
グループ登録、編集機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,5 @@ gem 'haml-rails'
 gem 'font-awesome-sass'
 
 gem 'devise'
+
+gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.1)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -104,6 +105,11 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.13.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (3.12.4)
     rack (2.2.2)
     rack-test (0.6.3)
@@ -200,6 +206,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   sass-rails (~> 5.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 @import "font-awesome";
 @import "modules/user";
 @import "modules/flash";
+@import "modules/group";
 
 html{
   height: 100%;

--- a/app/assets/stylesheets/modules/group.scss
+++ b/app/assets/stylesheets/modules/group.scss
@@ -1,0 +1,107 @@
+h1 {
+  letter-spacing: 2px;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+}
+h2 {
+  margin-bottom: 10px;
+  color: #f05050;
+  font-size: 14px;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+li {
+  margin: 0;
+  padding: 0;
+  font-size: 13px;
+}
+
+
+
+.chat-group-form {
+  width: 980px;
+  margin: 60px auto;
+  padding: 40px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-sizing: border-box;
+  &__errors {
+    margin: 30px 0;
+    padding: 20px 40px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+    text-align: center;
+  }
+  &__label {
+    display: block;
+    line-height: 50px;
+    font-weight: bold;
+    text-align: right;
+  }
+  &__input {
+    float: left;
+    width: 100%;
+    line-height: 30px;
+    padding: 10px 15px;
+    box-sizing: border-box;
+  }
+  &__action-btn {
+    display: inline-block;
+    padding: 12px 20px;
+    color: #fff;
+    background-color: #38aef0;
+    border: 0;
+  }
+  &__field {
+    margin-top: 30px;
+    &:after {
+      content: "";
+      clear: both;
+      display: block;
+    }
+    &--left {
+      float: left;
+      width: 30%;
+      padding-right: 20px;
+      padding-left: 20px;
+      box-sizing: border-box;
+    }
+    &--right {
+      float: right;
+      width: 70%;
+    }
+  }
+}
+
+.chat-group-user {
+  padding: 0 15px;
+  line-height: 50px;
+  font-size: 14px;
+  border-bottom: 1px solid #ddd;
+  &:after {
+    content: "";
+    clear: both;
+    display: block;
+  }
+  &__name {
+    float: left;
+  }
+  &__btn {
+    float: right;
+    display: inline-block;
+    cursor: pointer;
+    &--add {
+      color: #38aef0;
+    }
+    &--remove {
+      color: #f05050;
+    }
+  }
+}

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,8 +1,37 @@
 class GroupsController < ApplicationController
 
+  def index
+  end
+  
   def new
+    @group =Group.new
+    @group.users << current_user
   end
 
   def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @group = Group.find(params[:id])
+  end
+
+  def update
+    @group = Group.find(params[:id])
+    if @group.update(group_params)
+      redirect_to root_path, notice: "グループを変更しました"
+    else
+      render :edit
+    end
+  end
+
+  private
+  def group_params
+    params.require(:group).permit(:name, user_ids: [])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :group_users
+  has_many :groups, through: :group_users
+       
   validates :name, presence: true, uniqueness: true
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,25 @@
+= form_for group do |f|
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-form__field.clearfix
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,3 @@
+.chat-group-form
+  %h1 チャットグループ編集
+  = render partial: 'form', locals: { group: @group }

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,2 @@
+.wrappe
+  = render 'messages/side_bar'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,3 @@
+.chat-group-form
+  %h1 新規チャットグループ
+  = render partial: 'form', locals: { group: @group }

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -9,9 +9,10 @@
         = link_to edit_user_path(current_user), class: "cog-btn" do
           = icon('fas', 'cog',  class: "cog-btn__icon")
   .side-bar__group-list
-    = link_to "#" do
-      .group
-        %p.group__group-name
-          techcamp
-        %p.group__last-message
-          まだメッセージがありません
+    - current_user.groups.each do |group|
+      = link_to "#" do
+        .group
+          %p.group__group-name
+            = group.name
+          %p.group__last-message
+            まだメッセージがありません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   
   devise_for :users
-  root "messages#index"
+  root "groups#index"
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:new, :create]
+  resources :groups, only: [:index, :new, :create, :edit, :update]
 end


### PR DESCRIPTION
#WHAT
chatspace内で使用するグループを登録するページや編集するページを用意し、データベースにグループ情報を登録できるよう機能を実装した

#WHY
チャットスペースはグループ内でグループチャットができるというアプリケーションのためグループの名前、メンバーの登録が必要であるから。